### PR TITLE
Setup sub traces for nexrender to see where time is being spent.

### DIFF
--- a/packages/nexrender-action-webhook/index.js
+++ b/packages/nexrender-action-webhook/index.js
@@ -1,4 +1,3 @@
-const {name}   = require('./package.json');
 const https    = require('https');
 const fetch    = require('cross-fetch');
 

--- a/packages/nexrender-core/src/helpers/state.js
+++ b/packages/nexrender-core/src/helpers/state.js
@@ -1,9 +1,16 @@
+const tracer       = require('./tracer')
+
 module.exports = (job, settings, fn, fnName) => {
-    job.state = `render:${fnName}`;
+    var renderPrefix = `render.${fnName}`
+    return tracer.trace(renderPrefix, _span1 => {
+        job.state = `render:${fnName}`;
 
-    if (job.onChange) {
-        job.onChange(job, job.state);
-    }
-
-    return fn(job, settings);
+        if (job.onChange) {
+            return tracer.trace(`${renderPrefix}.onChange`, _span2 => {
+                return job.onChange(job, job.state);
+            })
+        }
+    
+        return fn(job, settings);
+    })
 }

--- a/packages/nexrender-core/src/helpers/tracer.js
+++ b/packages/nexrender-core/src/helpers/tracer.js
@@ -1,0 +1,20 @@
+var tracer
+
+class NoopSpan {
+    setTag(_key, _value) { return this }
+}
+
+class NoopTracer {
+    wrap(_name, cb) { return cb() }
+
+    trace(_name, cb) { return cb(new NoopSpan()) }
+}
+
+if(process.env.ENABLE_DATADOG_APM) {
+    tracer = require('dd-trace').init();
+} else {
+    // define noop tracer if datadog is not enabled
+    tracer =  new NoopTracer()
+}
+
+module.exports = tracer;

--- a/packages/nexrender-server/src/index.js
+++ b/packages/nexrender-server/src/index.js
@@ -1,5 +1,5 @@
 if(process.env.ENABLE_DATADOG_APM) {
-    var tracer = require('dd-trace').init();
+    require('dd-trace').init();
 }
 
 const cors   = require('micro-cors')

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -1,4 +1,5 @@
 const { createClient } = require('@nexrender/api')
+const tracer           = require('@nexrender/core/helpers/tracer')
 const { init, render } = require('@nexrender/core')
 const { getRenderingStatus } = require('@nexrender/types/job')
 
@@ -16,16 +17,10 @@ if(process.env.ENABLE_ROLLBAR) {
     });
 }
 
-
-
-var tracer = null;
 var renderWithTrace = null;
-
 if(process.env.ENABLE_DATADOG_APM) {
-    tracer = require('dd-trace').init();
     renderWithTrace = tracer.wrap('render', render);
 }
-
 
 const NEXRENDER_API_POLLING = process.env.NEXRENDER_API_POLLING || 30 * 1000;
 const NEXRENDER_TOLERATE_EMPTY_QUEUES = process.env.NEXRENDER_TOLERATE_EMPTY_QUEUES;


### PR DESCRIPTION
This PR adds a few new things to help obtain better monitoring for rendering processes. It adds:
- A shared tracer to the nexrender core package to ensure it is initialized just once when used in multiple function call layers.
- The new shared tracer has a NoOp tracer defined to ensure less logic spreads into other places of the application.
- Wraps around the `state` function to give metrics on individual render job's and their subsequent status at each part of the process.