### PR TITLE
Tag traces for more information in Datadog.

### DIFF
--- a/packages/nexrender-core/src/index.js
+++ b/packages/nexrender-core/src/index.js
@@ -147,10 +147,15 @@ class NoopSpan {
     setTag(_key, _value) { return this }
 }
 
+class NoopScope {
+    active() { return new NoopSpan() }
+}
 class NoopTracer {
     wrap(_name, cb) { return cb() }
-
+    
     trace(_name, cb) { return cb(new NoopSpan()) }
+
+    scope() { return new NoopScope() }
 }
 
 const initTracer = (settings) => {

--- a/packages/nexrender-core/src/index.js
+++ b/packages/nexrender-core/src/index.js
@@ -152,7 +152,7 @@ class NoopScope {
 }
 class NoopTracer {
     wrap(_name, cb) { return cb() }
-    
+
     trace(_name, cb) { return cb(new NoopSpan()) }
 
     scope() { return new NoopScope() }

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -64,6 +64,7 @@ const processJob = async (client, settings, job) => {
     } catch(err) {
         settings.logger.log(`[${job.uid}] error while updating job state to ${job.state}. Job abandoned.`)
         settings.logger.log(`[${job.uid}] error stack: ${err.stack}`)
+        settings.tracer?.scope()?.active()?.setTag('status', "error")
         return  "continue";
     }
 
@@ -79,11 +80,13 @@ const processJob = async (client, settings, job) => {
                     settings.logger.log(`[${job.uid}] error occurred: ${err.stack}`)
                     settings.logger.log(`[${job.uid}] render proccess stopped with error...`)
                     settings.logger.log(`[${job.uid}] continue listening next job...`)
+                    settings.tracer?.scope()?.active()?.setTag('status', "error")
                 }
             }
         }
 
         job.onRenderError = (job, err /* on render error */) => {
+            settings.tracer?.scope()?.active()?.setTag('status', "error")
             job.error = [].concat(job.error || [], [err.toString()]);
         }
 
@@ -188,6 +191,9 @@ const start = async (host, secret, settings, headers) => {
                 if (job === "break") return "break";
 
                 span.setTag('uid', job.uid);
+
+                if (job.tags) span.setTag('tags', job.tags.join(","))
+
                 return await processJob(client, settings, job)
             })
 


### PR DESCRIPTION
This PR should allow us to get more data about our different "queues" in nexrender by tagging each `job` `trace` with the `job.tags` that are sent over from `amplify`. It also introduces a `NoopScope` functionality to allow tags to be applied to the current span without having to pass it around.