### PR TITLE
Add in --max-render-timeout setting for nexrender workers and also fix redis TTL.

### DIFF
--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -173,7 +173,7 @@ opt('multiFramesCPU',       '--multi-frames-cpu');
 opt('reuse',                '--reuse');
 opt('stopOnError',          '--stop-on-error');
 opt('maxMemoryPercent',     '--max-memory-percent');
-opt('maxRenderTimeout', '--max-render-timeout');
+opt('maxRenderTimeout',     '--max-render-timeout');
 opt('imageCachePercent',    '--image-cache-percent');
 opt('wslMap',               '--wsl-map');
 opt('aeParams',             '--aerender-parameter');

--- a/packages/nexrender-cli/src/bin.js
+++ b/packages/nexrender-cli/src/bin.js
@@ -173,6 +173,7 @@ opt('multiFramesCPU',       '--multi-frames-cpu');
 opt('reuse',                '--reuse');
 opt('stopOnError',          '--stop-on-error');
 opt('maxMemoryPercent',     '--max-memory-percent');
+opt('maxRenderTimeout', '--max-render-timeout');
 opt('imageCachePercent',    '--image-cache-percent');
 opt('wslMap',               '--wsl-map');
 opt('aeParams',             '--aerender-parameter');

--- a/packages/nexrender-database-redis/src/index.js
+++ b/packages/nexrender-database-redis/src/index.js
@@ -41,16 +41,12 @@ const insert = async entry => {
     entry.updatedAt = now;
     entry.createdAt = now;
     
-<<<<<<< Updated upstream
-    await client.setAsync(`nexjob:${entry.uid}`, JSON.stringify(entry));
-=======
     if (process.env.NEXRENDER_REDIS_TTL) {
         // the EX below configures the expiration TTL (Time to live) in Redis.
         await client.setAsync(`nexjob:${entry.uid}`, JSON.stringify(entry), 'EX', process.env.NEXRENDER_REDIS_TTL);
     } else {
         await client.setAsync(`nexjob:${entry.uid}`, JSON.stringify(entry));
     }
->>>>>>> Stashed changes
 };
 
 const fetch = async uid => {

--- a/packages/nexrender-database-redis/src/index.js
+++ b/packages/nexrender-database-redis/src/index.js
@@ -41,7 +41,16 @@ const insert = async entry => {
     entry.updatedAt = now;
     entry.createdAt = now;
     
+<<<<<<< Updated upstream
     await client.setAsync(`nexjob:${entry.uid}`, JSON.stringify(entry));
+=======
+    if (process.env.NEXRENDER_REDIS_TTL) {
+        // the EX below configures the expiration TTL (Time to live) in Redis.
+        await client.setAsync(`nexjob:${entry.uid}`, JSON.stringify(entry), 'EX', process.env.NEXRENDER_REDIS_TTL);
+    } else {
+        await client.setAsync(`nexjob:${entry.uid}`, JSON.stringify(entry));
+    }
+>>>>>>> Stashed changes
 };
 
 const fetch = async uid => {

--- a/packages/nexrender-worker/readme.md
+++ b/packages/nexrender-worker/readme.md
@@ -76,6 +76,7 @@ Available settings (almost same as for `nexrender-core`):
 * `multiFrames` - boolean, providing true will attmpt to use aerender's built-in feature of multi frame rendering (false by default)
 * `multiFramesCPU` - integer between 1-100, the percentage of CPU used by multi frame rendering, if enabled (90 by default)
 * `reuse` - boolean, false by default, (from Adobe site): Reuse the currently running instance of After Effects (if found) to perform the render. When an already running instance is used, aerender saves preferences to disk when rendering has completed, but does not quit After Effects. If this argument is not used, aerender starts a new instance of After Effects, even if one is already running. It quits that instance when rendering has completed, and does not save preferences.
+* `maxRenderTimeout` - Number, set max render timeout in seconds, will abort rendering if it takes longer than this value (default: 0 - disabled)
 * `maxMemoryPercent` - integer, undefined by default, check [original documentation](https://helpx.adobe.com/after-effects/using/automated-rendering-network-rendering.html) for more info
 * `imageCachePercent` - integer, undefined by default, check [original documentation](https://helpx.adobe.com/after-effects/using/automated-rendering-network-rendering.html) for more info
 * `addLicense` - boolean, providing false will disable ae_render_only_node.txt license file auto-creation (true by default)

--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -37,7 +37,7 @@ const args = arg({
     '--reuse':                  Boolean,
 
     '--max-memory-percent':     Number,
-    '--max-render-timeout': Number,
+    '--max-render-timeout':     Number,
     '--image-cache-percent':    Number,
     '--polling':                Number,
     '--header':                 [String],

--- a/packages/nexrender-worker/src/bin.js
+++ b/packages/nexrender-worker/src/bin.js
@@ -37,6 +37,7 @@ const args = arg({
     '--reuse':                  Boolean,
 
     '--max-memory-percent':     Number,
+    '--max-render-timeout': Number,
     '--image-cache-percent':    Number,
     '--polling':                Number,
     '--header':                 [String],
@@ -144,6 +145,8 @@ if (args['--help']) {
                                             the value is a percentage of the installed RAM, and is otherwise a percentage of n.
                                             The value of n is 2 GB for 32-bit Windows, 4 GB for 64-bit Windows, and 3.5 GB for Mac OS.
 
+    --max-render-timeout                    Number, set max render timeout in seconds, will abort rendering if it takes longer than this value (default: 0 - disabled)
+
     --image-cache-percent                   (from Adobe site): specifies the maximum percentage of memory used
                                             to cache already rendered images and footage.
 
@@ -208,6 +211,7 @@ opt('stopOnError',          '--stop-on-error');
 opt('tolerateEmptyQueues',  '--tolerate-empty-queues');
 opt('exitOnEmptyQueue',     '--exit-on-empty-queue');
 opt('maxMemoryPercent',     '--max-memory-percent');
+opt('maxRenderTimeout',     '--max-render-timeout');
 opt('imageCachePercent',    '--image-cache-percent');
 opt('polling',              '--polling');
 opt('wslMap',               '--wsl-map');


### PR DESCRIPTION
Adds the new flag to the `nexrender-worker` cli and also fixes an issue with the redis TTL.